### PR TITLE
disable flash button if no target selected

### DIFF
--- a/src/Views/DfuView/DfuView.js
+++ b/src/Views/DfuView/DfuView.js
@@ -186,6 +186,8 @@ export default class DfuView extends Component {
             disabled={this.state.isFlashing}
             onChange={event => {
               this.setState({ currentRelease: event.target.value });
+              this.setState({ selectedUrl: null });
+              this.setState({ selectedFile: null });
             }}
             items={
               this.state.releaseList &&


### PR DESCRIPTION
Now it clears the selected firmware url from memory when changing release. This disables the flash button and will not flash the previously selected firmware