### PR TITLE
Move CLI view to menu tab

### DIFF
--- a/src/Views/CliView/CliView.js
+++ b/src/Views/CliView/CliView.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import Keyboard from "@material-ui/icons/Keyboard";
+import MenuItem from "@material-ui/core/MenuItem";
 import TextField from "@material-ui/core/TextField";
 import SwipeableDrawer from "@material-ui/core/SwipeableDrawer";
 import FCConnector from "../../utilities/FCConnector";
@@ -82,15 +82,14 @@ export default class CliView extends Component {
       <div>
         {!this.state.open &&
           !this.state.disabled && (
-            <Keyboard
-              style={{
-                position: "fixed",
-                bottom: "20px",
-                right: "20px",
-                color: this.props.theme.palette.primary[500]
+            <MenuItem
+              style={{ display: "flex", padding: 8 }}
+              onClick={() => {
+                this.toggleCli(true);
               }}
-              onClick={() => this.toggleCli(true)}
-            />
+            >
+              <div style={{ flexGrow: 1 }}>CLI</div>
+            </MenuItem>
           )}
         <SwipeableDrawer
           anchor="bottom"

--- a/src/Views/Connected.js
+++ b/src/Views/Connected.js
@@ -4,7 +4,6 @@ import AuxChannelView from "./AuxChannelView/AuxChannelView";
 import ConfigListView from "./ConfigListView/ConfigListView";
 import FeaturesView from "./FeaturesView/FeaturesView";
 import PortsView from "./PortsView/PortsView";
-import CliView from "./CliView/CliView";
 import FiltersView from "./FiltersView/FiltersView";
 import PidsView from "./PidView/PidView";
 import RatesView from "./RatesView/RatesView";
@@ -345,7 +344,6 @@ export default class Connected extends Component {
             appVersion={this.props.appVersion}
           />
           {contents}
-          <CliView handleSave={this.handleSave} theme={this.state.theme} />
           {this.state.openAssistant && (
             <AssistantView
               rebooting={this.props.rebooting}

--- a/src/Views/ResponsiveDrawerView.js
+++ b/src/Views/ResponsiveDrawerView.js
@@ -14,6 +14,7 @@ import "./Connected.css";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import CardMedia from "@material-ui/core/CardMedia";
+import CliView from "./CliView/CliView";
 
 const drawerWidth = 240;
 
@@ -106,6 +107,7 @@ function ResponsiveDrawer(props) {
               </MenuItem>
             );
           })}
+          <CliView />
         </List>
         <Divider />
       </div>


### PR DESCRIPTION
CLI view added to side menu. The "keyboard" button to open CLI has been replaced with MenuItem, allowing it to be clicked as a tab from the side menu.