### PR TITLE
Cli & telemetry fixes 0.3

### DIFF
--- a/public/server/express.js
+++ b/public/server/express.js
@@ -297,6 +297,19 @@ app.get("/telem/stop", (req, res) => {
 
     if (connectedDevice) {
       fcConnector.stopTelemetry(connectedDevice);
+      console.log("stopped telemetry");
+      res.sendStatus(200);
+    }
+  });
+});
+
+app.get("/telem/stopFast", (req, res) => {
+  devices.get((err, connectedDevice) => {
+    if (err) return res.status(400).send(err);
+
+    if (connectedDevice) {
+      fcConnector.stopFastTelemetry(connectedDevice);
+      console.log("stopped fast telemetry");
       res.sendStatus(200);
     }
   });

--- a/public/server/fcConnector/bxf.js
+++ b/public/server/fcConnector/bxf.js
@@ -362,6 +362,7 @@ const getTelemetry = (device, type) => {
     case "status": {
       return sendCommand(device, `msp 150`, 30, false).then(status => {
         if (status) {
+          console.log("nemesis_status");
           try {
             let data = new DataView(new Uint8Array(status).buffer, 12);
             let modeFlasCount = data.getUint8(15);

--- a/public/server/fcConnector/index.js
+++ b/public/server/fcConnector/index.js
@@ -311,6 +311,10 @@ module.exports = new class FcConnector {
   }
   stopTelemetry(deviceInfo) {
     clearInterval(websockets.wsServer.fastTelemetryInterval);
+    clearInterval(websockets.wsServer.slowTelemetryInterval);
+  }
+  stopFastTelemetry(deviceInfo) {
+    clearInterval(websockets.wsServer.fastTelemetryInterval);
   }
   rebootDFU(deviceInfo) {
     return bxfConnector.sendCommand(deviceInfo, "bl");

--- a/src/Views/CliView/CliView.js
+++ b/src/Views/CliView/CliView.js
@@ -24,14 +24,10 @@ export default class CliView extends Component {
       command: "",
       open: openState
     });
-    if (this.props.handleSave) {
-      if (openState) {
-        FCConnector.pauseTelemetry();
-      } else {
-        this.props.handleSave().then(() => {
-          FCConnector.resumeTelemetry();
-        });
-      }
+    if (openState) {
+      FCConnector.pauseTelemetry();
+    } else {
+      FCConnector.resumeTelemetry();
     }
   }
   replaceLast(update) {

--- a/src/Views/CliView/CliView.js
+++ b/src/Views/CliView/CliView.js
@@ -14,20 +14,23 @@ export default class CliView extends Component {
       cliBuffer: this.props.startText || "#flashEmu\n\n#",
       stayOpen: !!this.props.stayOpen || false,
       disabled: this.props.disabled || false,
-      open: this.props.stayOpen || !!this.props.open
+      open: this.props.stayOpen || !!this.props.open,
+      allowClose: true
     };
   }
   toggleCli(state) {
     let openState = this.state.stayOpen || state;
-    this.setState({
-      cliBuffer: this.props.startText || "#flashEmu\n\n#",
-      command: "",
-      open: openState
-    });
-    if (openState) {
-      FCConnector.pauseTelemetry();
-    } else {
-      FCConnector.resumeTelemetry();
+    if (openState || this.state.allowClose) {
+      this.setState({
+        cliBuffer: this.props.startText || "#flashEmu\n\n#",
+        command: "",
+        open: openState
+      });
+      if (openState) {
+        FCConnector.pauseTelemetry();
+      } else {
+        FCConnector.resumeTelemetry();
+      }
     }
   }
   replaceLast(update) {
@@ -64,6 +67,7 @@ export default class CliView extends Component {
       this.setState({ disabled: true });
       if (this.state.command) {
         let commands = this.state.command.split(/\r|\n/gim).filter(com => com);
+        this.setState({ allowClose: false });
         FCConnector.sendBulkCommands(
           commands.filter(line => !line.startsWith("#")),
           notifyResp => {
@@ -71,6 +75,7 @@ export default class CliView extends Component {
           }
         ).then(() => {
           this.setState({ disabled: false });
+          this.setState({ allowClose: true });
         });
       }
     }

--- a/src/Views/PreFlightCheckView/AttitudeView.js
+++ b/src/Views/PreFlightCheckView/AttitudeView.js
@@ -91,7 +91,7 @@ export default class AttitudeView extends Component {
 
   componentWillUnmount() {
     window.removeEventListener("resize", this.onWindowResize);
-    FCConnector.stopTelemetry();
+    FCConnector.stopFastTelemetry();
     FCConnector.webSockets.removeEventListener(
       "message",
       this.handleStatusMessage

--- a/src/Views/RXView/RXTelemView.js
+++ b/src/Views/RXView/RXTelemView.js
@@ -38,7 +38,7 @@ export default class RXTelemView extends Component {
 
   componentWillUnmount() {
     FCConnector.webSockets.removeEventListener("message", this.handleRXData);
-    FCConnector.stopTelemetry();
+    FCConnector.stopFastTelemetry();
   }
   render() {
     return (

--- a/src/utilities/FCConnector.js
+++ b/src/utilities/FCConnector.js
@@ -137,6 +137,7 @@ export default new class FCConnector {
   }
   pauseTelemetry() {
     this.paused = true;
+    console.log("paused telemetry");
     this.stopTelemetry();
   }
   resumeTelemetry() {
@@ -162,6 +163,10 @@ export default new class FCConnector {
   }
   stopTelemetry() {
     return fetch(`${this.serviceUrl}/telem/stop`);
+  }
+
+  stopFastTelemetry() {
+    return fetch(`${this.serviceUrl}/telem/stopFast`);
   }
 
   uploadFont(name = "butterflight") {


### PR DESCRIPTION
Further improvements to the CLI in master, based on recent work to 1.0.0 branch
The cli was slow when telemetry is running in the background. It had not reliably stopped all telemetry when cli is opened.
Changed some behavior to treat fast & slow telemetry differently. 
Slow telemetry is like status, vbat, cpu for the top bar.
Fast telemetry is like accelerometer view, and rx stick view.

One remaining bug, that isn't causing problems, is that when cli is closed, some fast telemetry is resumed. it should resume only the telemetry that was paused, to keep the current page working