### PR TITLE
turn off gh-actions building all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ on:
   push:
     tags:
     - '*'
-    branches:
-    - '*'
+    #branches:
+    #- '*'
   pull_request:
     branches:
     - '*'


### PR DESCRIPTION
* turn off gh-actions building all branches
* prefer building only when triggered via tag
* how to:
```shell
git checkout [master|branch|commit]
git tag buildMe
git push [origin|upstream] buildMe
git tag --delete buildMe   #delete local tag
git push --delete [origin|upstream] buildMe   #delete remote tag
```

* this PR will only create artifacts. it does not send to releases as EmuFlight & EmuConfigurator does.