### PR TITLE
fix GitHub Actions Building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: true
       max-parallel: 3
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2016]
         #os: [ubuntu-18.04, macos-10.15, windows-2016]
     continue-on-error: true
 
@@ -54,7 +54,7 @@ jobs:
           echo "Repo: ${{ github.REPOSITORY }}"
         continue-on-error: true
 
-      - name: Build Linux
+      - name: Build-Setup Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         env:
           CI: false
@@ -68,13 +68,21 @@ jobs:
           sudo n 12
           npm install usb@1.6.1 --save
           npm install --save --save-exact --include=dev
+        continue-on-error: false
+
+      - name: Build Linux
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        env:
+          CI: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           echo "############ pack #############"
           npm run electron-pack
           echo "############ dist #############"
           npm run dist --publish=never
         continue-on-error: false
 
-      - name: Build OSX
+      - name: Build-Setup OSX
         if: ${{ startsWith(matrix.os, 'macos') }}
         env:
           CI: false
@@ -88,6 +96,14 @@ jobs:
           npm install -g n
           sudo n 12
           npm install usb@1.6.1 --save
+        continue-on-error: false
+
+      - name: Build OSX
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        env:
+          CI: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           npm install --save --save-exact --include=dev
           echo "############ pack #############"
           npm run electron-pack
@@ -95,8 +111,7 @@ jobs:
           npm run dist --publish=never
         continue-on-error: false
 
-
-      - name: Build Windows
+      - name: Build-Setup Windows
         if: ${{ startsWith(matrix.os, 'windows') }}
         env:
           CI: false
@@ -110,6 +125,14 @@ jobs:
           npm config set python %USERPROFILE%\.windows-build-tools\python27\python.exe
           npm install usb@1.6.1 --save
           npm install --save --save-exact --include=dev
+        continue-on-error: false
+
+      - name: Build Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        env:
+          CI: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           echo "############ pack #############"
           npm run electron-pack
           echo "############ dist #############"
@@ -146,7 +169,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@master
         with:
-          name: EmuConfigurator-${{ github.ACTOR }}-${{ github.RUN_NUMBER }}
+          name: Nemesis-${{ github.ACTOR }}-${{ github.RUN_NUMBER }}
         continue-on-error: false
 
       - name: list artifacts
@@ -160,11 +183,11 @@ jobs:
         uses: softprops/action-gh-release@master
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./emuflight-configurator*.???
+          files: ./Nemesis*.*
           draft: true
           prerelease: true
           tag_name: ${{ github.RUN_NUMBER }}   # use the build Number, but we manually change to version so that it creates a version-tag on release
-          name:  DRAFT / EmuConfigurator / GitHub Build ${{ github.RUN_NUMBER }}
+          name:  DRAFT / Nemesis / GitHub Build ${{ github.RUN_NUMBER }}
           body: |
             ### Build: ${{ github.RUN_NUMBER }}
             ### Commit: ${{ github.SHA }}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "devDependencies": {
     "concurrently": "3.5.0",
     "electron": "^4.2.12",
-    "electron-builder": "^22.7.0",
+    "electron-builder": "^22.11.7",
     "electron-packager": "12.2.0",
     "electron-react-devtools": "^0.5.3",
     "electron-rebuild": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "devDependencies": {
     "concurrently": "3.5.0",
     "electron": "^4.2.12",
-    "electron-builder": "^22.11.7",
+    "electron-builder": "~22.10.5",
     "electron-packager": "12.2.0",
     "electron-react-devtools": "^0.5.3",
     "electron-rebuild": "1.8.2",


### PR DESCRIPTION
- downgrade electron-builder ~22.10.5
- separate some github actions
- binaries need testing for all previously working functionality

Build-Artifacts for testing are here (342MB): https://drive.google.com/file/d/1qbNakjuBLczVMUeonoJGZ93PJV1ad0ei/view?usp=sharing